### PR TITLE
Changes for adapting to `fastapi-users` latest API change.

### DIFF
--- a/open_needs_server/database.py
+++ b/open_needs_server/database.py
@@ -35,7 +35,7 @@ async def create_db_and_tables():
         await conn.run_sync(Base.metadata.create_all)
 
 
-async def get_async_session() -> AsyncSession:
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_maker() as session:
         yield session
 

--- a/open_needs_server/extensions/extension_viewer/routers.py
+++ b/open_needs_server/extensions/extension_viewer/routers.py
@@ -3,8 +3,8 @@ from fastapi import APIRouter, Request, Depends
 from .schemas import ExtensionBaseSchema
 
 from open_needs_server.extensions.user_security.dependencies import current_superuser
-from open_needs_server.extensions.user_security.schemas import UserDBSchema
-
+from open_needs_server.extensions.user_security.models import UserModel
+from ..user_security.models import UserModel
 
 extension_viewer_router = APIRouter(
     prefix="/api/extensions",
@@ -16,7 +16,7 @@ extension_viewer_router = APIRouter(
 
 @extension_viewer_router.get("/", response_model=list[ExtensionBaseSchema])
 async def rest_read_extensions(request: Request,
-                               superuser: UserDBSchema = Depends(current_superuser)):
+                               superuser: UserModel = Depends(current_superuser)):
     ons_app = request.app
     extensions = []
 

--- a/open_needs_server/extensions/need/routers.py
+++ b/open_needs_server/extensions/need/routers.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from open_needs_server.extensions.base import ONSExtension
 from open_needs_server.extensions.user_security.dependencies import current_active_user, RoleChecker
-from open_needs_server.extensions.user_security.schemas import UserDBSchema
+from open_needs_server.extensions.user_security.models import UserModel
 
 from .schemas import NeedReturnSchema, NeedCreateSchema, NeedUpdateSchema
 from .api import *
@@ -37,7 +37,7 @@ async def rest_read_items(skip: int = 0,
                           limit: int = 100,
                           db: Session = Depends(get_db),
                           ext: ONSExtension = Depends(get_extension),
-                          user: UserDBSchema = Depends(current_active_user)
+                          user: UserModel = Depends(current_active_user)
                           ):
     """Needed roles: view_organizations_all"""
     needs = await get_needs(ext, db, skip=skip, limit=limit)
@@ -51,7 +51,7 @@ async def rest_read_items(skip: int = 0,
 async def rest_create_need(need: NeedCreateSchema,
                            db: Session = Depends(get_db),
                            ext: ONSExtension = Depends(get_extension),
-                           user: UserDBSchema = Depends(current_active_user)
+                           user: UserModel = Depends(current_active_user)
                            ):
     need_json = jsonable_encoder(need)
 
@@ -70,7 +70,7 @@ async def rest_create_need(need: NeedCreateSchema,
 async def rest_read_need(need_id: int,
                          db: AsyncSession = Depends(get_db),
                          ext: ONSExtension = Depends(get_extension),
-                         user: UserDBSchema = Depends(current_active_user)):
+                         user: UserModel = Depends(current_active_user)):
     db_need = await get_need(ext, db, need_id=need_id)
     if db_need is None:
         raise HTTPException(status_code=404, detail="Need not found")

--- a/open_needs_server/extensions/organization/routers.py
+++ b/open_needs_server/extensions/organization/routers.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from open_needs_server.dependencies import get_db
 from open_needs_server.extensions.base import ONSExtension
 from open_needs_server.extensions.user_security.dependencies import current_active_user, RoleChecker
-from open_needs_server.extensions.user_security.schemas import UserDBSchema
+from open_needs_server.extensions.user_security.models import UserModel
 
 from .schemas import OrganizationReturnSchema, OrganizationCreateSchema, OrganizationShortSchema
 from .api import OnsOrganizationNotFound, get_organization_by_title, create_organization, get_organization, \
@@ -35,7 +35,7 @@ delete_organizations = RoleChecker(['delete_organizations_all'])
 async def rest_read_organizations(skip: int = 0, limit: int = 100,
                                   db: AsyncSession = Depends(get_db),
                                   ext: ONSExtension = Depends(get_extension),
-                                  user: UserDBSchema = Depends(current_active_user)):
+                                  user: UserModel = Depends(current_active_user)):
 
     ext.print(f'user: {user.email} - {user.is_active}')
     db_organizations = await get_organizations(ext, db, skip=skip, limit=limit)

--- a/open_needs_server/extensions/project/api.py
+++ b/open_needs_server/extensions/project/api.py
@@ -31,7 +31,7 @@ async def create_project(db: AsyncSession,
     for domain_id in project['domains']:
         domain_db = await get_domain(db, domain_id)
         if not domain_db:
-            raise HTTPException(f'Unknown domain id: {domain_id}')
+            raise HTTPException(404, detail=f'Unknown domain id: {domain_id}')
         domains_db.append(domain_db)
 
     cursor = await db.execute(insert(ProjectModel), project)
@@ -46,8 +46,8 @@ async def create_project(db: AsyncSession,
 
 # Project specific
 async def get_organization_project_by_title(db: AsyncSession,
-                                       organization_id: int,
-                                       project_title: int):
+                                            organization_id: int,
+                                            project_title: int):
     result = await db.execute(select(ProjectModel).filter(ProjectModel.title == project_title,
                                                           ProjectModel.organization_id == organization_id))
     return result.scalars().first()
@@ -93,3 +93,4 @@ async def delete_project(ext: ONSExtension,
 
 class OnsProjectNotFound(OnsExtensionException):
     """A requested object could not be found"""
+    pass

--- a/open_needs_server/extensions/project/routers.py
+++ b/open_needs_server/extensions/project/routers.py
@@ -3,7 +3,7 @@ from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from open_needs_server.extensions.base import ONSExtension
-from open_needs_server.extensions.user_security.schemas import UserDBSchema
+from open_needs_server.extensions.user_security.models import UserModel
 from open_needs_server.extensions.user_security.dependencies import current_active_user, RoleChecker
 
 from .schemas import ProjectSchema, ProjectCreateSchema, ProjectChangeSchema
@@ -36,7 +36,7 @@ delete_projects = RoleChecker(['delete_projects_all'])
 async def rest_read_projects(skip: int = 0, limit: int = 100,
                              db: AsyncSession = Depends(get_db),
                              ext: ONSExtension = Depends(get_extension),
-                             user: UserDBSchema = Depends(current_active_user)
+                             user: UserModel = Depends(current_active_user)
                              ):
     db_projects = await get_projects(db, skip=skip, limit=limit)
     return db_projects
@@ -51,7 +51,7 @@ async def rest_read_projects(skip: int = 0, limit: int = 100,
 async def rest_create_project(project: ProjectCreateSchema,
                               db: AsyncSession = Depends(get_db),
                               ext: ONSExtension = Depends(get_extension),
-                              user: UserDBSchema = Depends(current_active_user)
+                              user: UserModel = Depends(current_active_user)
                               ):
     project_json = jsonable_encoder(project)
     db_project = await get_organization_project_by_title(db, organization_id=project.organization_id,
@@ -72,7 +72,7 @@ async def rest_create_project(project: ProjectCreateSchema,
 async def rest_read_project(project_id: int,
                             db: AsyncSession = Depends(get_db),
                             ext: ONSExtension = Depends(get_extension),
-                            user: UserDBSchema = Depends(current_active_user)
+                            user: UserModel = Depends(current_active_user)
                             ):
     db_project = await get_project(db, project_id=project_id)
     if db_project is None:
@@ -90,7 +90,7 @@ async def rest_update_project(project_id: int,
                               project: ProjectChangeSchema,
                               db: AsyncSession = Depends(get_db),
                               ext: ONSExtension = Depends(get_extension),
-                              user: UserDBSchema = Depends(current_active_user)
+                              user: UserModel = Depends(current_active_user)
                               ):
     project_json = jsonable_encoder(project)
     db_project = await get_project(db, project_id=project_id)
@@ -111,7 +111,7 @@ async def rest_update_project(project_id: int,
 async def rest_delete_project(project_id: int,
                               db: AsyncSession = Depends(get_db),
                               ext: ONSExtension = Depends(get_extension),
-                              user: UserDBSchema = Depends(current_active_user)
+                              user: UserModel = Depends(current_active_user)
                               ):
     """Deletes a selected organizations by its ID"""
     try:

--- a/open_needs_server/extensions/user_security/__init__.py
+++ b/open_needs_server/extensions/user_security/__init__.py
@@ -8,7 +8,7 @@ from open_needs_server.version import VERSION
 from open_needs_server.database import engine
 
 from .security import auth_backend, get_user_manager
-from .schemas import UserReturnSchema, UserCreateSchema, UserUpdateSchema, UserDBSchema
+from .schemas import UserReturnSchema, UserCreateSchema, UserUpdateSchema
 from .routers import roles_router
 from .api import create_role, get_role_by_name
 from .dependencies import fastapi_users_ext
@@ -34,11 +34,11 @@ class UserSecurityExtension(ONSExtension):
                              prefix="/auth/jwt",
                              tags=["auth"])
 
-        self.register_router(fastapi_users_ext.get_register_router(),
+        self.register_router(fastapi_users_ext.get_register_router(UserReturnSchema, UserCreateSchema),
                              prefix="/auth",
                              tags=["auth"])
 
-        self.register_router(fastapi_users_ext.get_verify_router(),
+        self.register_router(fastapi_users_ext.get_verify_router(UserReturnSchema),
                              prefix="/auth",
                              tags=["auth"])
 
@@ -46,7 +46,7 @@ class UserSecurityExtension(ONSExtension):
                              prefix="/auth",
                              tags=["auth"])
 
-        self.register_router(fastapi_users_ext.get_users_router(),
+        self.register_router(fastapi_users_ext.get_users_router(UserReturnSchema, UserUpdateSchema),
                              prefix="/users",
                              tags=["users"])
 

--- a/open_needs_server/extensions/user_security/models.py
+++ b/open_needs_server/extensions/user_security/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Integer, Column, String, ForeignKey, Table
 from sqlalchemy.orm import relationship
 
-from fastapi_users.db import SQLAlchemyBaseUserTable
+from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 
 from open_needs_server.database import Base
 
@@ -11,7 +11,7 @@ roles_users_table = Table('roles_users', Base.metadata,
                           )
 
 
-class UserModel(Base, SQLAlchemyBaseUserTable):
+class UserModel(SQLAlchemyBaseUserTableUUID, Base):
     def __repr__(self) -> str:
         return f"{self.email}"
 

--- a/open_needs_server/extensions/user_security/routers.py
+++ b/open_needs_server/extensions/user_security/routers.py
@@ -6,6 +6,7 @@ from open_needs_server.dependencies import get_db
 from open_needs_server.exceptions import ONSExtensionException
 
 from .schemas import RoleReturnSchema, RoleUpdateSchema
+# from .models import UserModel
 from .api import get_roles, get_role_by_name, update_role
 from .dependencies import RoleChecker, current_active_user
 

--- a/open_needs_server/extensions/user_security/schemas.py
+++ b/open_needs_server/extensions/user_security/schemas.py
@@ -1,5 +1,7 @@
+import uuid
+
 from pydantic import BaseModel
-from fastapi_users import models
+from fastapi_users import schemas
 from typing import List, Optional
 
 
@@ -20,7 +22,7 @@ class RoleReturnSchema(RoleBaseSchema):
         orm_mode = True
 
 
-class UserReturnSchema(models.BaseUser):
+class UserReturnSchema(schemas.BaseUser[uuid.UUID]):
     # roles: Optional[List[RoleReturnSchema]] | None = []
 
     class Config:
@@ -29,7 +31,7 @@ class UserReturnSchema(models.BaseUser):
 
 # CREATE
 
-class UserCreateSchema(models.BaseUserCreate):
+class UserCreateSchema(schemas.BaseUserCreate):
     pass
 
 
@@ -39,13 +41,5 @@ class RoleUpdateSchema(BaseModel):
     users: List[str]
 
 
-class UserUpdateSchema(models.BaseUserUpdate):
+class UserUpdateSchema(schemas.BaseUserUpdate):
     pass
-
-
-# DB
-
-class UserDBSchema(UserReturnSchema, models.BaseUserDB):
-    pass
-
-

--- a/open_needs_server/extensions/user_security/security.py
+++ b/open_needs_server/extensions/user_security/security.py
@@ -1,18 +1,19 @@
 """
 Setups the user handling and all needed dependencies, managers and co.
 """
+import uuid
 
 from fastapi import Depends, Request
 from typing import Optional
 
-from fastapi_users import BaseUserManager
+from fastapi_users import BaseUserManager, UUIDIDMixin
 from fastapi_users.db import SQLAlchemyUserDatabase
 from fastapi_users.authentication import AuthenticationBackend, BearerTransport, JWTStrategy
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import UserModel
-from .schemas import UserDBSchema, UserCreateSchema
+# from .schemas import UserDBSchema, UserCreateSchema
 
 from open_needs_server.dependencies import get_db
 
@@ -21,7 +22,7 @@ SECRET = "SECRET"
 
 
 async def get_user_db(session: AsyncSession = Depends(get_db)):
-    yield SQLAlchemyUserDatabase(UserDBSchema, session, UserModel)
+    yield SQLAlchemyUserDatabase(session, UserModel)
 
 
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
@@ -38,8 +39,7 @@ auth_backend = AuthenticationBackend(
 )
 
 
-class UserManager(BaseUserManager[UserCreateSchema, UserModel]):
-    user_db_model = UserDBSchema
+class UserManager(UUIDIDMixin, BaseUserManager[UserModel, uuid.UUID]):
     reset_password_token_secret = SECRET
     verification_token_secret = SECRET
 

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -2,7 +2,7 @@ rich
 uvicorn
 pydantic
 fastapi
-fastapi-users[sqlalchemy2]
+fastapi-users[sqlalchemy]
 aiosqlite
 dynaconf
 sqladmin


### PR DESCRIPTION
The PR marks important changes in how we manage User models and their ID using the latest `fastapi-users` API (`v10.x.x`). To implement the changes, I followed the guideline by `fastapi-users` for migrating from **[9.x.x -> 10.x.x](https://github.com/fastapi-users/fastapi-users/blob/685984e6e3495226bfd16c405c6d7edc2871a25e/docs/migration/9x_to_10x.md)**.

Important changes made were:

- [x] Removed the old SQLAlchemy dependency support, so the current dependency is now `fastapi-users[sqlalchemy]` instead of `fastapi-users[sqlalchemy2]` 
- [x] Changed the User model base class for SQLAlchemy to support UUID by default. Instead of `class UserModel(Base, SQLAlchemyBaseUserTable)` use `class UserModel(SQLAlchemyBaseUserTableUUID, Base)`
- [x] Slightly changed the User manager class. Instead of `class UserManager(BaseUserManager[UserCreateSchema, UserModel])` use `class UserManager(UUIDIDMixin, BaseUserManager[UserModel, uuid.UUID])`. As a result, you must remove the `user_db_model` class property.
- [x] Changed the Pydantic schemas for User. As a result of this change, you don't need to pass the Pydantic schemas when initializing the `FastAPIUsers` class but you need to pass the Pydantic schemas when initializing the router that needs them: `get_register_router`, `get_verify_router` and `get_users_router`. 
- [x] Changed all instances where the user argument is passed from `user: UserDBSchema` to `user: UserModel` 